### PR TITLE
fix: Header going back to choose version screen

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -17,7 +17,7 @@ const getHeader = () => {
 const Header = ({ onSetSidebarOpen }) => (
     <Container>
         {document.location.hash.match('yokai') ? (
-            <Link to="/">
+            <Link to="/home">
                 <FontAwesomeIcon icon="arrow-left" />
             </Link>
         ) : (


### PR DESCRIPTION
# Pull Request Template
 
## Description

This MR fixes the header going back to the choose yokai version screen, now it goes back to the yokais list screen 

Fixes (#11)