### PR TITLE
feat: Add redesign checkbox shared component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yokaidex",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "A PWA with the info from Yokai watch",
     "license": "MIT",
     "homepage": "https://joaopedrodcf.github.io/yokaidex",

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -17,6 +17,7 @@ import { elements, ranks, tribes } from '../../mocks';
 import yokaisGame1 from '../../mocks/yokai-watch-1/yokais';
 import yokaisGame2 from '../../mocks/yokai-watch-2/yokais';
 import yokaisGame3 from '../../mocks/yokai-watch-3/yokais';
+import Checkbox from '../shared/checkbox';
 
 class Main extends Component {
     constructor(props) {
@@ -71,7 +72,7 @@ class Main extends Component {
     }
 
     handleCheckbox(event) {
-        const checkboxtype = event.target.getAttribute('checkboxtype');
+        const checkboxtype = event.target.getAttribute('data-checkbox-type');
         const type = event.target.name.toLowerCase();
         const { checked } = event.target;
         const filterType = this.state[checkboxtype];
@@ -183,16 +184,18 @@ class Main extends Component {
                             </Button>
                             {tribesCheckbox.map(type => (
                                 <InputContainer key={type}>
-                                    <input
-                                        type="checkbox"
-                                        checked={tribe.includes(
-                                            type.toLowerCase()
-                                        )}
-                                        name={type}
-                                        checkboxtype="tribe"
-                                        onChange={this.handleCheckbox}
-                                    />
-                                    <label htmlFor={type}>{type}</label>
+                                    <label>
+                                        <Checkbox
+                                            type="checkbox"
+                                            checked={tribe.includes(
+                                                type.toLowerCase()
+                                            )}
+                                            name={type}
+                                            checkboxtype="tribe"
+                                            onChange={this.handleCheckbox}
+                                            label={type}
+                                        />
+                                    </label>
                                 </InputContainer>
                             ))}
                         </Collapsible>
@@ -212,16 +215,18 @@ class Main extends Component {
                             </Button>
                             {ranksCheckbox.map(type => (
                                 <InputContainer key={type}>
-                                    <input
-                                        type="checkbox"
-                                        checked={rank.includes(
-                                            type.toLowerCase()
-                                        )}
-                                        name={type}
-                                        checkboxtype="rank"
-                                        onChange={this.handleCheckbox}
-                                    />
-                                    <label htmlFor={type}>{type}</label>
+                                    <label>
+                                        <Checkbox
+                                            type="checkbox"
+                                            checked={rank.includes(
+                                                type.toLowerCase()
+                                            )}
+                                            name={type}
+                                            checkboxtype="rank"
+                                            onChange={this.handleCheckbox}
+                                            label={type}
+                                        />
+                                    </label>
                                 </InputContainer>
                             ))}
                         </Collapsible>
@@ -241,16 +246,18 @@ class Main extends Component {
                             </Button>
                             {elementsCheckbox.map(type => (
                                 <InputContainer key={type}>
-                                    <input
-                                        type="checkbox"
-                                        checked={element.includes(
-                                            type.toLowerCase()
-                                        )}
-                                        name={type}
-                                        checkboxtype="element"
-                                        onChange={this.handleCheckbox}
-                                    />
-                                    <label htmlFor={type}>{type}</label>
+                                    <label>
+                                        <Checkbox
+                                            type="checkbox"
+                                            checked={element.includes(
+                                                type.toLowerCase()
+                                            )}
+                                            name={type}
+                                            checkboxtype="element"
+                                            onChange={this.handleCheckbox}
+                                            label={type}
+                                        />
+                                    </label>
                                 </InputContainer>
                             ))}
                         </Collapsible>
@@ -259,7 +266,7 @@ class Main extends Component {
                         <thead>
                             <tr>
                                 <th onClick={this.handleSort} thtype="name">
-                                    Name{' '}
+                                    Name
                                     {sort === 'name' ? (
                                         <FontAwesomeIcon
                                             icon={

--- a/src/components/main/style.js
+++ b/src/components/main/style.js
@@ -80,6 +80,6 @@ export const Collapsible = styled.div`
     flex-direction: column;
 
     div {
-        display: ${props => (props.isCollapsed ? 'none' : 'block')};
+        display: ${props => props.isCollapsed && 'none'};
     }
 `;

--- a/src/components/shared/checkbox/Checkbox.js
+++ b/src/components/shared/checkbox/Checkbox.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+    CheckboxContainer,
+    HiddenCheckbox,
+    StyledCheckbox,
+    Icon
+} from './style';
+
+const Checkbox = ({ checked, name, checkboxtype, onChange, label }) => (
+    <CheckboxContainer checkboxtype={checkboxtype}>
+        <HiddenCheckbox
+            checked={checked}
+            checkboxtype={checkboxtype}
+            checkbox-type={checkboxtype}
+            onChange={onChange}
+            name={name}
+        />
+        <StyledCheckbox checked={checked} checkboxtype={checkboxtype}>
+            <Icon viewBox="0 0 24 24">
+                <polyline points="20 6 9 17 4 12" />
+            </Icon>
+        </StyledCheckbox>
+        <span>{label}</span>
+    </CheckboxContainer>
+);
+
+export default Checkbox;

--- a/src/components/shared/checkbox/index.js
+++ b/src/components/shared/checkbox/index.js
@@ -1,0 +1,1 @@
+export { default } from './Checkbox';

--- a/src/components/shared/checkbox/style.js
+++ b/src/components/shared/checkbox/style.js
@@ -1,0 +1,54 @@
+import styled from 'styled-components';
+
+export const CheckboxContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    span {
+        margin-left: 12px;
+    }
+`;
+
+export const Icon = styled.svg`
+    fill: none;
+    stroke: white;
+    stroke-width: 2px;
+`;
+
+// Be aware that the custom attributes only work like this
+// For example 'data-ANYTHING' or 'aria-ANYTHING'
+// Custom attributes like 'checkboxtype' that we had previously don't work
+// Maybe in a feature styled-components version we can remove this
+export const HiddenCheckbox = styled.input.attrs(props => ({
+    type: 'checkbox',
+    'data-checkbox-type': props.checkboxtype
+}))`
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+`;
+
+export const StyledCheckbox = styled.div`
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    background: ${props => (props.checked ? '#e57373' : '#e4b9b9')};
+    border-radius: 3px;
+    transition: all 150ms;
+
+    ${HiddenCheckbox}:focus + & {
+        box-shadow: 0 0 0 3px pink;
+    }
+
+    ${Icon} {
+        visibility: ${props => (props.checked ? 'visible' : 'hidden')};
+    }
+`;

--- a/src/globalStyle.js
+++ b/src/globalStyle.js
@@ -21,6 +21,12 @@ body {
     flex-direction: column;
 }
 
+*,
+*::before,
+*::after {
+    box-sizing: inherit;
+}
+
 
 /*
     font-size: 62.5%;


### PR DESCRIPTION
# Pull Request Template
 
## Description
 
New design to the checkboxes this was heavily based on the following tutorial by Cole Bemis:
https://medium.com/@colebemis/building-a-checkbox-component-with-react-and-styled-components-8d3aa1d826dd

I had some hard problems make this work and left comments in our codebase.
Basically, Styled-components don't let you create every `custom html attributes` you want.
We had the checkboxtype custom attribute, and for nothing with would be passed to the HTML, so search a bit and found out some examples, the ones like this `aria-anything` worked and also `data-anything`, so migrated the custom attribute to `data-checkbox-type`.

Fixes # (12)
![checkbox](https://user-images.githubusercontent.com/11476152/52527960-e85d7b80-2cc9-11e9-8826-ee42b432da5e.PNG)
