### PR TITLE
fix: Improve lazy loading with image shared component with isToLazyLoad

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
-        "precommit": "lint-staged",
         "predeploy": "npm run build",
         "deploy": "gh-pages -d build"
     },
@@ -60,6 +59,11 @@
         "not ie <= 11",
         "not op_mini all"
     ],
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
     "lint-staged": {
         "*.js": [
             "eslint --fix",

--- a/src/components/card/style.js
+++ b/src/components/card/style.js
@@ -44,7 +44,8 @@ export const SpecialDiv = styled.div`
     display: flex;
     flex-direction: column;
 
-    div {
+    div,
+    img {
         margin-bottom: 42px;
     }
 

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -386,13 +386,16 @@ class Main extends Component {
                                         }}
                                     >
                                         <td>
-                                            <Image
-                                                imageUrl={yokai.image}
-                                                altText={yokai.name}
-                                                size="medium"
-                                                isThumbnail
-                                            />
-                                            {yokai.name}
+                                            <div>
+                                                <Image
+                                                    imageUrl={yokai.image}
+                                                    altText={yokai.name}
+                                                    size="medium"
+                                                    isThumbnail
+                                                    isToLazyLoad
+                                                />
+                                                {yokai.name}
+                                            </div>
                                         </td>
                                         <td>
                                             <Image

--- a/src/components/shared/image/Image.js
+++ b/src/components/shared/image/Image.js
@@ -1,15 +1,31 @@
 import React from 'react';
 import { SCImage, SCLazyLoad } from './style';
 
-const Image = ({ imageUrl, altText, size, isThumbnail }) => (
-    <SCLazyLoad size={size} offsetVertical={1000}>
-        <SCImage
-            src={imageUrl}
-            alt={altText}
-            size={size}
-            isThumbnail={isThumbnail}
-        />
-    </SCLazyLoad>
+const Image = ({ imageUrl, altText, size, isThumbnail, isToLazyLoad }) => (
+    <>
+        {isToLazyLoad ? (
+            <SCLazyLoad
+                size={size}
+                offsetBottom={500}
+                throttle={250}
+                debounce={false}
+            >
+                <SCImage
+                    src={imageUrl}
+                    alt={altText}
+                    size={size}
+                    isThumbnail={isThumbnail}
+                />
+            </SCLazyLoad>
+        ) : (
+            <SCImage
+                src={imageUrl}
+                alt={altText}
+                size={size}
+                isThumbnail={isThumbnail}
+            />
+        )}
+    </>
 );
 
 export default Image;

--- a/src/components/shared/image/style.js
+++ b/src/components/shared/image/style.js
@@ -34,6 +34,9 @@ export const SCImage = styled.img`
 `;
 
 export const SCLazyLoad = styled(LazyLoad)`
+    display: flex;
+    align-items: center;
+
     height: ${props => {
         if (props.size === 'small') return '35px';
         if (props.size === 'medium') return '62px';


### PR DESCRIPTION
# Pull Request Template
 
## Description
 
So this PR comes because of problems with lazyload strategy, in my opinion, the lazyload should only be done in yokais images, because all of them are different.

In `version 3` of the game there are `758 images` for each yokai, so the lazy load is really important, but the ranks, tribe and attribute repeat in the `Main.js` so lazy load would make as they were not loaded!

So now in this PR we are only lazy loading the yokai images.

Also It was changed the way the lazy load works to load even when you are scrolling and a throttling of 250 worked well. Aslo changed to `offsetBottom` instead of `offsetVertical`.

From the documentation of react-lazy-load:

`The offsetVertical option allows you to specify how far above and below the viewport you want to begin displaying your content.`

`The offsetBottom option allows you to specify how far below the viewport you want to begin displaying your content.`

So I think the second one is more what we want but could be good to get some feedback.

 