### PR TITLE
feat: Add infinite scroll to bost perfomance on the load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yokaidex",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "A PWA with the info from Yokai watch",
     "license": "MIT",
     "homepage": "https://joaopedrodcf.github.io/yokaidex",

--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,15 @@ class App extends Component {
                     sidebar={sidebar}
                     open={sidebarOpen}
                     onSetOpen={this.onSetSidebarOpen}
-                    styles={{ sidebar: { background: 'white' } }}
+                    styles={{
+                        sidebar: { background: 'white' },
+                        root: {
+                            overflow: 'initial'
+                        },
+                        content: {
+                            overflowY: 'initial'
+                        }
+                    }}
                 >
                     <Header onSetSidebarOpen={this.onSetSidebarOpen} />
                     <Routes

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -82,8 +82,8 @@ const Card = ({
                         {utils
                             .getEvolution(evolutions, evolutionIndexes)
                             .filter(evo => evo.type === 'level')
-                            .map(evo => (
-                                <ContainerEvolutions>
+                            .map((evo, index) => (
+                                <ContainerEvolutions key={index}>
                                     <Row>
                                         <Column>
                                             <Link

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -37,7 +37,9 @@ class Main extends Component {
             sort: '',
             orderAsc: true,
             yokais: yokaisGame1,
-            isCollapsed: true
+            isCollapsed: true,
+            pageNumber: 0,
+            yokaisToShow: 50
         };
 
         this.handleCheckbox = this.handleCheckbox.bind(this);
@@ -46,6 +48,7 @@ class Main extends Component {
         this.handleResetFilter = this.handleResetFilter.bind(this);
         this.handleCollapse = this.handleCollapse.bind(this);
         this.handleFormSubmit = this.handleFormSubmit.bind(this);
+        this.handleScroll = this.handleScroll.bind(this);
     }
 
     componentDidMount() {
@@ -64,7 +67,13 @@ class Main extends Component {
                 break;
         }
 
+        document.addEventListener('scroll', this.handleScroll);
+
         this.setState({ yokais });
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('scroll', this.handleScroll);
     }
 
     goTo(name, tribe) {
@@ -118,6 +127,15 @@ class Main extends Component {
         event.preventDefault();
     }
 
+    handleScroll() {
+        const scrollTopHalfSize = 3000;
+        const { pageNumber } = this.state;
+
+        if (window.pageYOffset > scrollTopHalfSize * (pageNumber + 1)) {
+            this.setState({ pageNumber: pageNumber + 1 });
+        }
+    }
+
     render() {
         const {
             tribe,
@@ -127,7 +145,9 @@ class Main extends Component {
             sort,
             orderAsc,
             yokais,
-            isCollapsed
+            isCollapsed,
+            pageNumber,
+            yokaisToShow
         } = this.state;
         const tribesCheckbox = [
             'Brave',
@@ -370,6 +390,7 @@ class Main extends Component {
 
                                     return aux;
                                 })
+                                .slice(0, (pageNumber + 1) * yokaisToShow)
                                 .map(yokai => (
                                     <tr
                                         key={yokai.name + yokai.tribe}

--- a/src/components/shared/image/Image.js
+++ b/src/components/shared/image/Image.js
@@ -6,7 +6,7 @@ const Image = ({ imageUrl, altText, size, isThumbnail, isToLazyLoad }) => (
         {isToLazyLoad ? (
             <SCLazyLoad
                 size={size}
-                offsetBottom={500}
+                offset={500}
                 throttle={250}
                 debounce={false}
             >


### PR DESCRIPTION
# Pull Request Template
 
## Description
 
So as we know the app was having issues with all the dom nodes being loaded in the first time, we even implemented lazy load to the images to boost performance but it was not enough.
This PR bring infinite scroll to the list of yo-kais, I think it still needs some work so please give me advice in the merge review.
This somewhat fixes the problems of the filters because when a person wants to filter a yokai normal it does at the load, but if she scrolls all down and goes back up the performance will deteriorate again, to fix this we need to go into a more complicated bidirectional infinite scroll!
But let's not overcomplicate for now and try to boost the performance with this.

Also as a bonus this fixes the app not going for the top when changing pages, this happened because of a problem with the integration of `react-sidebar` and the solution was found here: https://github.com/balloob/react-sidebar/issues/4